### PR TITLE
Adding 'Cancel' Button and repositioning 'Reset' button

### DIFF
--- a/RSSignatureView.h
+++ b/RSSignatureView.h
@@ -10,4 +10,5 @@
 @property (nonatomic, strong) RSSignatureViewManager *manager;
 -(void) onSaveButtonPressed;
 -(void) onClearButtonPressed;
+-(void) onCancelButtonPressed;
 @end

--- a/RSSignatureView.m
+++ b/RSSignatureView.m
@@ -58,6 +58,17 @@
         [saveButton setBackgroundColor:[UIColor colorWithRed:255/255.f green:255/255.f blue:255/255.f alpha:1.f]];
         [sign addSubview:saveButton];
 
+        //Cancel button
+        UIButton *cancelButton = [UIButton buttonWithType:UIButtonTypeRoundedRect];
+        [cancelButton addTarget:self action:@selector(onCancelButtonPressed)
+        forControlEvents:UIControlEventTouchUpInside];
+        [cancelButton setTitle:@"Cancel" forState:UIControlStateNormal];
+        [cancelButton.titleLabel setFont:[UIFont systemFontOfSize:22]];
+
+        cancelButton.frame = CGRectMake(0, 0, buttonSize.width, buttonSize.height);
+        [cancelButton setBackgroundColor:[UIColor colorWithRed:255/255.f green:255/255.f blue:255/255.f alpha:1.f]];
+        [sign addSubview:cancelButton];
+
         //Clear button
         UIButton *clearButton = [UIButton buttonWithType:UIButtonTypeRoundedRect];
         [clearButton addTarget:self action:@selector(onClearButtonPressed)
@@ -65,9 +76,10 @@
         [clearButton setTitle:@"Reset" forState:UIControlStateNormal];
         [clearButton.titleLabel setFont:[UIFont systemFontOfSize:22]];
 
-        clearButton.frame = CGRectMake(0, 0, buttonSize.width, buttonSize.height);
+        clearButton.frame = CGRectMake(sign.bounds.size.width / 2, 600, 0, buttonSize.width, buttonSize.height);
         [clearButton setBackgroundColor:[UIColor colorWithRed:255/255.f green:255/255.f blue:255/255.f alpha:1.f]];
         [sign addSubview:clearButton];
+
 
     }
     _loaded = true;
@@ -107,6 +119,10 @@
         NSString *base64Encoded = [imageData base64EncodedStringWithOptions:0];
         [self.manager saveImage:tempPath withEncoded:base64Encoded];
     }
+}
+
+-(void) onCancelButtonPressed {
+    [self.manager emitCancel];
 }
 
 -(void) onClearButtonPressed {

--- a/RSSignatureViewManager.h
+++ b/RSSignatureViewManager.h
@@ -4,4 +4,5 @@
 @interface RSSignatureViewManager : RCTViewManager
 @property (nonatomic, strong) RSSignatureView *signView;
 -(void) saveImage:(NSString *) aTempPath withEncoded: (NSString *) aEncoded;
+-(void) emitCancel;
 @end

--- a/RSSignatureViewManager.m
+++ b/RSSignatureViewManager.m
@@ -23,6 +23,12 @@ RCT_EXPORT_MODULE()
     return dispatch_get_main_queue();
 }
 
+-(void) emitCancel {
+    [self.bridge.eventDispatcher
+     sendDeviceEventWithName:@"onCancelEvent"
+     body:[NSNull null]];
+}
+
 -(void) saveImage:(NSString *) aTempPath withEncoded: (NSString *) aEncoded {
     [self.bridge.eventDispatcher
      sendDeviceEventWithName:@"onSaveEvent"

--- a/SignatureCapture.js
+++ b/SignatureCapture.js
@@ -8,10 +8,8 @@ var {
   View
 } = React;
 
-var Component = requireNativeComponent(
-                                  'RSSignatureView',
-                                  null
-                                );
+var Component = requireNativeComponent('RSSignatureView', null);
+
 var styles = {
   signatureBox: {
     flex: 1
@@ -24,7 +22,7 @@ var styles = {
   }
 };
 
-var subscription;
+var saveEvent, cancelEvent;
 
 var SignatureCapture = React.createClass({
   propTypes: {
@@ -32,14 +30,13 @@ var SignatureCapture = React.createClass({
   },
 
   componentDidMount: function() {
-    subscription = DeviceEventEmitter.addListener(
-        'onSaveEvent',
-        this.props.onSaveEvent
-    );
+    saveEvent = DeviceEventEmitter.addListener('onSaveEvent', this.props.onSaveEvent);
+    cancelEvent = DeviceEventEmitter.addListener('onCancelEvent', this.props.onCancelEvent);
   },
 
   componentWillUnmount: function() {
-    subscription.remove();
+    saveEvent.remove();
+    cancelEvent.remove();
   },
 
   render: function() {


### PR DESCRIPTION
A cancel button would allow the user to void a signature before saving. Currently to achieve the same result, the user would have to press ‘reset’ and then ‘save’.
